### PR TITLE
fix: Fix typo; Catch non-mcce pdb format.

### DIFF
--- a/mcce4_tools/detect_hbonds
+++ b/mcce4_tools/detect_hbonds
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+"""
+Tool file:  detect_hbonds
+
+Codebase: /mcce4/detect_hbonds.py
+"""
+import sys
+
+from mcce4.detect_hbonds import cli
+
+
+if __name__ == "__main__":
+    sys.exit(cli())


### PR DESCRIPTION
1. Added a tool command line: `detect_hbonds`
2. Capture error when parsing a conventional pdb Closes #54