### PR TITLE
fix: Code review

### DIFF
--- a/mcce4_tools/mcce4/cms_analysis_wc/cli.py
+++ b/mcce4_tools/mcce4/cms_analysis_wc/cli.py
@@ -11,7 +11,6 @@ from itertools import islice
 import logging
 from pathlib import Path
 from pprint import pprint
-from shutil import copyfile
 import sys
 
 from mcce4.cms_analysis_wc import APP_NAME, IONIZABLES

--- a/mcce4_tools/mcce4/cms_analysis_wc/parameters.py
+++ b/mcce4_tools/mcce4/cms_analysis_wc/parameters.py
@@ -192,12 +192,6 @@ def load_crgms_param(filepath: str) -> Tuple[dict, dict]:
     if correl_lines:
         crgms_dict["correl_resids"] = correl_lines
 
-    # p, e = crgms_dict.get("msout_file", "pH7eH0ms.txt")[:-4].lower().split("eh")
-    # ph = p.removeprefix("ph")
-    # eh = e.removesuffix("ms")
-    # crgms_dict["ph"] = ph
-    # crgms_dict["eh"] = eh
-
     charge_histograms = defaultdict(dict)
     remove_keys = []
     for k in crgms_dict:
@@ -225,12 +219,12 @@ def load_crgms_param(filepath: str) -> Tuple[dict, dict]:
 
 
 def check_res_list(correl_lst: list, res_lst: list, conf_info: np.ndarray) -> list:
-    """Perform at most 2 checks on res_list depending on presence of the other arguments:
+    """Perform at most 2 checks on res_list depending on the other arguments:
     - Whether items in correl_lst are in res_list;
     - Whether items in the validated correl_lst are in the free conformers space.
     """
     if conf_info is None or not len(conf_info):
-        sys.exit("Lookup array 'conf_info' is empty")
+        sys.exit("Lookup array 'conf_info' is empty!")
 
     new = []
     for res in correl_lst:
@@ -240,7 +234,7 @@ def check_res_list(correl_lst: list, res_lst: list, conf_info: np.ndarray) -> li
             logger.warning(f"Ignoring {res!r} from correl_lst: {res[:3]} not in residue_kinds.")
     correl_lst = new
     if correl_lst:
-        free_ci = conf_info[np.where(conf_info[:, -3])==1]  # is_free field
+        free_ci = conf_info[np.where(conf_info[:, -3]==1)]  # is_free field
         correl2 = deepcopy(correl_lst)
         for cid in correl_lst:  # check confid field:
             if not len(free_ci[np.where(free_ci[:, 1] == cid)]):

--- a/mcce4_tools/mcce4/cms_analysis_wc/plots.py
+++ b/mcce4_tools/mcce4/cms_analysis_wc/plots.py
@@ -5,13 +5,13 @@ Module: plots.py
 
   Plots for Protonation microstate analysis with weighted correlation.
 """
+import os
 from pathlib import Path
 import sys
 from typing import Tuple
 import warnings
 warnings.simplefilter("error", UserWarning)
 
-import os
 os.environ['QT_QPA_PLATFORM'] = 'xcb'
 try:
     import matplotlib as mpl
@@ -74,15 +74,20 @@ def energy_distribution(
     graph_hist = plt.hist(energies, bins=100, alpha=0.6)
     Y = graph_hist[0]
     pdf_data = Y.max() / max(y) * y
-    plt.plot(energies, pdf_data, label="approx. skewnorm", color="indigo")
-    plt.title(f"{skewness= :.2f} {mean= :.2f} {std= :.2f}", fontsize=fs)
+    dist_label = ("approx. Boltzmann\n"
+                  "with skewnorm fit.\n"
+                 f"  skewness: {skewness:.2f}\n"
+                 f"  mean: {mean:.2f}\n"
+                 f"  std: {std:.2f}")
+    plt.plot(energies, pdf_data, label=dist_label, color="indigo")
     plt.xlabel(f"{kind_lbl} Microstate Energy (Kcal/mol)", fontsize=fs)
     plt.ylabel("Count", fontsize=fs)
     plt.yticks(fontsize=fs)
     plt.xticks(fontsize=fs)
     plt.tick_params(axis="x", direction="out", length=8, width=2)
     plt.tick_params(axis="y", direction="out", length=8, width=2)
-    plt.legend()
+    plt.legend(fontsize="large")
+
     fig_fp = out_dir.joinpath(save_name)
     fig.savefig(fig_fp, dpi=300, bbox_inches="tight")
 
@@ -139,7 +144,7 @@ def crgms_energy_histogram(
     )
     try:
         plt.yscale("log")
-        ax.set_ylabel("log$_{10}$(Count)", fontsize=fs)
+        ax.set_ylabel("Count", fontsize=fs)
     except UserWarning:
         plt.yscale("linear")
         ax.set_ylabel("Energy (Kcal/mol)", fontsize=fs)
@@ -193,13 +198,12 @@ def corr_heatmap(
         off_diag_mask = ~np.eye(corr_array.shape[0], dtype=bool)
         # Check if all off-diagonal elements are zero
         if np.all(corr_array[off_diag_mask] == 0):
-            logging.warning("All off-diagonal correlation values are 0.00: not plotting.")
+            print("Warning: All off-diagonal correlation values are 0: not plotting.")
             return
 
     if df_corr.shape[0] > 14 and fig_size == HEATMAP_SIZE:
-        logger.warning(
-            ("With a matrix size > 14 x 14, the fig_size argument" f" should be > {HEATMAP_SIZE}.")
-        )
+        print("Warning: With a matrix size > 14 x 14, the fig_size argument",
+              f"should be > {HEATMAP_SIZE}.")
 
     n_resample = 8
     top = mpl.colormaps["Reds_r"].resampled(n_resample)

--- a/mcce4_tools/ms_top2pdbs
+++ b/mcce4_tools/ms_top2pdbs
@@ -6,18 +6,19 @@ Tool file: ms_top2pdbs
 Purpose:
 Create pdb & pqr files for the topN tautomeric protonation microstates,
 along with a summary file & a listing of the N charge vectors.
+Note: Files in an existing output folder are overwritten.
 
-Defaults: mcce_dir=.; ph=7; eh=0; n_top=5; --overwrite=False.
+Defaults: mcce_dir=.; ph=7; eh=0; n_top=5; residue_kinds=ionizable residues
 
 Examples:
   Using all defaults:
     > ms_top2pdbs
   Passing residues kinds: comma-separated; order & case insensitive:
-    > ms_top2pdbs -residue_kinds _CL,his,GLU
+    > ms_top2pdbs -residue_kinds _CL,his,PL9
 """
 import sys
 from mcce4.topn_cms_to_pdbs import cli
 
 
 if __name__ == "__main__":
-    sys.exit(cli(tool_prompt=True))
+    sys.exit(cli())

--- a/mcce4_tools/tools.info
+++ b/mcce4_tools/tools.info
@@ -97,13 +97,15 @@ ms_sample2pdbs    :: Generate a random sample of MCCE microstates in mcce pdb fo
 
 ms_top2pdbs       :: Create pdb & pqr files for the topN tautomeric protonation microstates,
                      along with a summary file & a listing of the N charge vectors.
+                     Files in an existing output folder are overwritten.
                      Defaults:
-                     pH=7.0; n_top=5; min_occ=0.0; residue_kinds=ionizable res; --overwrite=False.
+                     pH=7.0; n_top=5; min_occ=0.0; residue_kinds=mcce4.constants.IONIZABLE_RES
                      Examples:
                       > ms_top2pdbs         # use all defaults
                       > ms_top2pdbs -eh 30  # Eh titration at ph7
                      Passing residues kinds: comma-separated; order & case insensitive:
                       > ms_top2pdbs -residue_kinds _CL,his,GLU
+                     Note: residue_kinds not in the default list are appended to it.
 --------------------------------------------------------------------------------------------------
 
 ms_split_msout    :: Obtain a reduced msout file, preserving the original as all_<msout_file>.


### PR DESCRIPTION
* Review for differing net charge in `ms_protonation` 'all_crg_count_resoi.csv' viz. `ms_top2pdbs` 'top5_ms.tsv' 
The difference is due to the retrieval of __tautomeric__ charge microstates in `ms_top2pdbs` viz. (non differentiated) charge microstates in `ms_protonation`.
* Review for code simplification & corrections:
  - `ms_top2pdbs`: Now overwrites files in an existing output folder
  - `ms_protonation`: The filtering to obtain the histogram for "Protonation MS Counts for Residues of Interest" was wrong & is removed (the "Protonation MS Counts" histogram always include the residues of interest)