### PR TITLE
MSout_np Total Charge Calculation Bug

### DIFF
--- a/mcce4_tools/mcce4/msout_np.py
+++ b/mcce4_tools/mcce4/msout_np.py
@@ -1186,6 +1186,7 @@ class MSout_np:
         data = []
         ix_state = 1 if self.mc_load == "all" else 0
         for it, itm in enumerate(top_cms):
+            
             if ix_state == 1:
                 # [ idx, list(state), totE, averE, occ, count ]
                 fields = [itm[0]]   # the shared index
@@ -1193,7 +1194,19 @@ class MSout_np:
                 fields = [it]  # current index
 
             state = itm[ix_state].copy()
+            charge_vec = []
             for i, s in enumerate(state):
+                if self.cms_resids[i][:3] == "HIS":
+                    if self.with_tautomers:
+                        s = HIS0_tautomers[s]
+                        if isinstance(s, str):
+                            charge_vec.append(0)
+                        else:
+                            charge_vec.append(1)
+
+                else:
+                    charge_vec.append(s)
+
                 if self.with_tautomers:
                     if self.cms_resids[i][:3] == "HIS":
                         # s is a pseudo charge
@@ -1243,7 +1256,7 @@ class MSout_np:
             df.reset_index(inplace=True)
             df.rename(columns={"index":"residues"}, inplace=True)
             df["info"] = info_dat
-            
+            #df.to_csv('top_df.csv')
             return df
         
         # Format as per original specs in Raihan's microstate_analysis_code:

--- a/mcce4_tools/mcce4/topn_cms_to_pdbs.py
+++ b/mcce4_tools/mcce4/topn_cms_to_pdbs.py
@@ -518,7 +518,7 @@ def write_tcrgms_pdbs(
           referring to the cms-associated ms.
     """
     step2_fh = open(out_dir.parent.joinpath("step2_out.pdb"))
-
+    #tcrgms_df.to_csv('test.csv')
     top_df = tcrgms_df.set_index("residues")
     # isolate the series of associated ms indices:
     ids = top_df.iloc[0][:-1]
@@ -722,7 +722,7 @@ Input options:
             self.mcce_files[2],
             res_kinds=self.residue_kinds,
             with_tautomers=True,
-            reduced_ms_rows=self.args.reduced_ms_rows,
+            reduced_ms_rows=self.args.reduced_ms_rows
         )
 
         return


### PR DESCRIPTION
Fixed bug in msout_np where total charge of top n charge microstates was being calculated incorrectly. One neutral his conformation was being counted as +1 and the +1 conformation was being counted as +2